### PR TITLE
[FEATURE] 리포트 요청 방식 수정(프론트 요청-비동기 -> 동기식 대기)

### DIFF
--- a/app/controllers/report_controller.py
+++ b/app/controllers/report_controller.py
@@ -1,6 +1,6 @@
 import asyncio
-from app.dtos.request_dto import ReportGenerationReq
-from app.dtos.response_dto import ReportGenerationRes
+from app.dtos.request_dto import ReportGenerationReq, ReportGenerationSyncReq
+from app.dtos.response_dto import ReportGenerationRes, ReportGenerationSyncRes
 from app.services.analyzer_service import analyzer_service
 
 
@@ -13,6 +13,17 @@ class ReportController:
             mainReportId=request.mainReportId,
             status="ACCEPTED",
             message="리포트 생성 요청이 접수되었습니다."
+        )
+
+    async def generate_report_sync(self, request: ReportGenerationSyncReq) -> ReportGenerationSyncRes:
+        result = await analyzer_service.analyze_sync(request)
+
+        return ReportGenerationSyncRes(
+            mainReportId=request.mainReportId,
+            detailReportId=request.detailReportId,
+            status=result["status"],
+            content=result["content"],
+            errorMessage=result["errorMessage"]
         )
 
 

--- a/app/dtos/request_dto.py
+++ b/app/dtos/request_dto.py
@@ -16,3 +16,10 @@ class EmbeddingReq(BaseModel):
 
 class ProjectEmbeddingReq(BaseModel):
     text: str
+
+
+class ReportGenerationSyncReq(BaseModel):
+    mainReportId: int
+    detailReportId: int
+    gitUrl: str
+    githubToken: str

--- a/app/dtos/response_dto.py
+++ b/app/dtos/response_dto.py
@@ -20,3 +20,11 @@ class CallbackReq(BaseModel):
 class EmbeddingRes(BaseModel):
     vector: List[float]
     dimension: int
+
+
+class ReportGenerationSyncRes(BaseModel):
+    mainReportId: int
+    detailReportId: int
+    status: str
+    content: Optional[Any] = None
+    errorMessage: Optional[str] = None

--- a/app/routes/report_route.py
+++ b/app/routes/report_route.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter
-from app.dtos.request_dto import ReportGenerationReq
-from app.dtos.response_dto import ReportGenerationRes
+from app.dtos.request_dto import ReportGenerationReq, ReportGenerationSyncReq
+from app.dtos.response_dto import ReportGenerationRes, ReportGenerationSyncRes
 from app.controllers.report_controller import report_controller
 
 router = APIRouter()
@@ -9,3 +9,9 @@ router = APIRouter()
 @router.post("/generate", response_model=ReportGenerationRes)
 async def generate_report(request: ReportGenerationReq):
     return await report_controller.generate_report(request)
+
+
+@router.post("/generate/sync", response_model=ReportGenerationSyncRes)
+async def generate_report_v2(request: ReportGenerationSyncReq) -> ReportGenerationSyncRes:
+    """동기식 리포트 생성 - 분석 완료 후 결과 직접 반환"""
+    return await report_controller.generate_report_sync(request)

--- a/app/services/analyzer_service.py
+++ b/app/services/analyzer_service.py
@@ -3,8 +3,9 @@ import json
 import subprocess
 import asyncio
 import logging
+import time
 from dataclasses import dataclass
-from app.dtos.request_dto import ReportGenerationReq
+from app.dtos.request_dto import ReportGenerationReq, ReportGenerationSyncReq
 from app.services.git_service import (
     clone_repository,
     cleanup_directory,
@@ -203,6 +204,57 @@ class AnalyzerService:
         )
         result = await gemini_service.analyze_code(prompt)
         return result
+
+    async def analyze_sync(self, request: ReportGenerationSyncReq) -> dict:
+        """동기식 분석 - 결과를 직접 반환"""
+        temp_dir = None
+        log_prefix = f"[detail:{request.detailReportId}, main:{request.mainReportId}]"
+        start_time = time.time()
+
+        logger.info(f"{log_prefix} 동기 분석 시작 - {request.gitUrl}")
+
+        try:
+            author_name, author_email = get_github_user_from_token(request.githubToken)
+            logger.info(f"{log_prefix} 분석 대상: {author_name} ({author_email})")
+
+            clone_start = time.time()
+            logger.info(f"{log_prefix} Git 클론 중...")
+            temp_dir = await asyncio.to_thread(
+                clone_repository, request.gitUrl, request.githubToken, settings.temp_dir
+            )
+            clone_elapsed = time.time() - clone_start
+            logger.info(f"{log_prefix} Git 클론 완료 ({clone_elapsed:.2f}초)")
+
+            analysis_start = time.time()
+            logger.info(f"{log_prefix} 기여자 분석 중...")
+            analysis_result = await self._analyze_contributor(
+                temp_dir, request.gitUrl, author_name, author_email
+            )
+            analysis_elapsed = time.time() - analysis_start
+            logger.info(f"{log_prefix} AI 분석 완료 ({analysis_elapsed:.2f}초)")
+
+            total_elapsed = time.time() - start_time
+            logger.info(f"{log_prefix} 리포트 생성 완료 - 총 소요시간: {total_elapsed:.2f}초")
+
+            return {
+                "status": "SUCCESS",
+                "content": analysis_result,
+                "errorMessage": None
+            }
+
+        except Exception as e:
+            total_elapsed = time.time() - start_time
+            logger.error(f"{log_prefix} 오류 발생 ({total_elapsed:.2f}초) - {str(e)}")
+            return {
+                "status": "FAILED",
+                "content": None,
+                "errorMessage": str(e)
+            }
+
+        finally:
+            if temp_dir:
+                cleanup_directory(temp_dir)
+                logger.info(f"{log_prefix} 임시 디렉토리 정리 완료")
 
     def _get_commit_files_quick(self, dir_path: str, commit_hash: str) -> list:
         try:


### PR DESCRIPTION
# 요약
<!--해당 PR에 대한 설명 혹은 이미지등을 넣어주세요. -->

- 새로운 API 엔드포인트 `/generate/sync` 추가 (스프링 GET reports/v2)
- 비동기 방식과 달리, 리포트 분석 완료 후 결과를 즉시 응답하도록 구현
- 동기식 리포트 요청 및 응답 DTO와 관련 컨트롤러 및 서비스 로직 정의


# 연관 이슈 및 Close 할 이슈 작성
-- PR 시 다음과 같이 작성

- #20

close #20

# Pull Request 체크리스트

<img width="1274" height="306" alt="image" src="https://github.com/user-attachments/assets/c5a548c3-4a22-4c5e-bcac-fcb94a6e46bc" />

## TODO

- [x] 최종 결과물을 확인했는가?
- [x] 의미 있는 커밋 메시지를 작성했는가?
   