### PR TITLE
[FEATURE] 리포트 techstack 분류 기능 추가

### DIFF
--- a/app/controllers/report_controller.py
+++ b/app/controllers/report_controller.py
@@ -23,7 +23,8 @@ class ReportController:
             detailReportId=request.detailReportId,
             status=result["status"],
             content=result["content"],
-            errorMessage=result["errorMessage"]
+            errorMessage=result["errorMessage"],
+            techstacks=result.get("techstacks", [])
         )
 
 

--- a/app/dtos/request_dto.py
+++ b/app/dtos/request_dto.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict
+from typing import Any, Dict, List, Optional
 from pydantic import BaseModel
 
 
@@ -9,6 +9,7 @@ class ReportGenerationReq(BaseModel):
     callbackUrl: str
     embeddingCallbackUrl: str
     githubToken: str
+    techstacks: Optional[List[str]] = None
 
 
 class EmbeddingReq(BaseModel):
@@ -25,3 +26,4 @@ class ReportGenerationSyncReq(BaseModel):
     gitUrl: str
     githubToken: str
     embeddingCallbackUrl: str
+    techstacks: Optional[List[str]] = None

--- a/app/dtos/response_dto.py
+++ b/app/dtos/response_dto.py
@@ -15,6 +15,7 @@ class CallbackReq(BaseModel):
     status: str
     content: Optional[Any] = None
     errorMessage: Optional[str] = None
+    techstacks: Optional[List[str]] = None
 
 
 class EmbeddingRes(BaseModel):
@@ -37,3 +38,4 @@ class ReportGenerationSyncRes(BaseModel):
     status: str
     content: Optional[Any] = None
     errorMessage: Optional[str] = None
+    techstacks: Optional[List[str]] = None

--- a/app/prompts/combined_report_prompt.py
+++ b/app/prompts/combined_report_prompt.py
@@ -13,6 +13,9 @@ Contribution Ratio: {contribution_ratio}%
 === Tech Stack ===
 {tech_stack}
 
+=== Available Techstack Enum Values ===
+{available_techstacks}
+
 === Project Scale ===
 Total Code Files: {total_files}
 Total Lines of Code: {total_lines}
@@ -36,9 +39,10 @@ Files Modified: {files_modified}
 === Other Contributors ===
 {other_contributors}
 
-Based on the information above, analyze the contribution of "{author_name}" and provide BOTH a main report (summary) and a detailed report in the following JSON format.
+Based on the information above, analyze the contribution of "{author_name}" and provide a main report (summary), a detailed report, AND a techstacks array (only the techstacks that "{author_name}" personally used based on their commits and code changes) in the following JSON format.
 
 {{
+    "techstacks": ["techstack enums that {author_name} directly used"],
     "main": {{
         "overview": {{
             "summary": "프로젝트 목적과 해결하는 문제 (2-3문장)",
@@ -174,7 +178,17 @@ Important Requirements:
     - "보안": Only if security features are implemented (JWT, OAuth, encryption, etc.)
   - Consider adding specific categories like "테스트", "배포", "인프라", "상태관리", "스타일링" if applicable to the project.
 - Respond strictly in JSON format only.
+- **techstacks Rules (CRITICAL)**:
+  - The "techstacks" field must be a string array containing ONLY values from the "Available Techstack Enum Values" section above.
+  - Select ONLY the techstacks that "{author_name}" actually used based on their commits, code changes, and modified files — NOT the entire project's tech stack.
+  - Do NOT include techstacks that "{author_name}" did not directly work with, even if the project uses them.
+  - Do NOT include root position values (BACKEND, FRONTEND, INFRA) - only include specific technologies.
+  - Return exact enum names as strings (e.g., "JAVA", "SPRINGBOOT", "REACT", "TYPESCRIPT").
+  - Example: If "{author_name}" worked on Java backend with Spring Boot and MySQL queries, return ["JAVA", "SPRINGBOOT", "MYSQL"].
 """
+
+
+from typing import List, Optional
 
 
 def get_combined_report_prompt(
@@ -194,8 +208,11 @@ def get_combined_report_prompt(
     file_changes: str,
     other_contributors: str,
     development_period: str,
-    test_code_count: int
+    test_code_count: int,
+    available_techstacks: Optional[List[str]] = None
 ) -> str:
+    techstacks_str = ", ".join(available_techstacks) if available_techstacks else "No techstacks provided"
+
     return COMBINED_REPORT_PROMPT.format(
         repo_url=repo_url,
         author_name=author_name,
@@ -213,5 +230,6 @@ def get_combined_report_prompt(
         file_changes=file_changes,
         other_contributors=other_contributors,
         development_period=development_period,
-        test_code_count=test_code_count
+        test_code_count=test_code_count,
+        available_techstacks=techstacks_str
     )

--- a/app/services/analyzer_service.py
+++ b/app/services/analyzer_service.py
@@ -100,16 +100,21 @@ class AnalyzerService:
 
             logger.info(f"{log_prefix} 기여자 분석 중...")
             analysis_result = await self._analyze_contributor(
-                temp_dir, request.gitUrl, author_name, author_email
+                temp_dir, request.gitUrl, author_name, author_email, request.techstacks
             )
             logger.info(f"{log_prefix} AI 분석 완료")
+
+            # techstacks 추출 (AI 응답에서)
+            techstacks = analysis_result.pop("techstacks", []) if isinstance(analysis_result, dict) else []
+            logger.info(f"{log_prefix} AI 응답 techstacks: {techstacks}")
 
             logger.info(f"{log_prefix} 콜백 전송 중...")
             await callback_service.send_success(
                 callback_url=request.callbackUrl,
                 detail_report_id=request.detailReportId,
                 main_report_id=request.mainReportId,
-                content=analysis_result
+                content=analysis_result,
+                techstacks=techstacks
             )
             logger.info(f"{log_prefix} 콜백 전송 완료 (SUCCESS)")
 
@@ -169,7 +174,7 @@ class AnalyzerService:
             )
             logger.info(f"{log_prefix} 임베딩 콜백 전송 완료 (FAILED)")
 
-    def _analyze_contributor_sync(self, dir_path: str, repo_url: str, author_name: str, author_email: str) -> str:
+    def _analyze_contributor_sync(self, dir_path: str, repo_url: str, author_name: str, author_email: str, available_techstacks: list = None) -> str:
         tech_stack = detect_tech_stack(dir_path)
         tech_stack_str = json.dumps(tech_stack, ensure_ascii=False, indent=2)
 
@@ -237,14 +242,15 @@ class AnalyzerService:
             file_changes=file_changes,
             other_contributors=other_contributors_str,
             development_period=development_period,
-            test_code_count=test_code_count
+            test_code_count=test_code_count,
+            available_techstacks=available_techstacks
         )
 
         return prompt
 
-    async def _analyze_contributor(self, dir_path: str, repo_url: str, author_name: str, author_email: str) -> dict:
+    async def _analyze_contributor(self, dir_path: str, repo_url: str, author_name: str, author_email: str, available_techstacks: list = None) -> dict:
         prompt = await asyncio.to_thread(
-            self._analyze_contributor_sync, dir_path, repo_url, author_name, author_email
+            self._analyze_contributor_sync, dir_path, repo_url, author_name, author_email, available_techstacks
         )
         result = await gemini_service.analyze_code(prompt)
         return result
@@ -272,7 +278,7 @@ class AnalyzerService:
             analysis_start = time.time()
             logger.info(f"{log_prefix} 기여자 분석 중...")
             analysis_result = await self._analyze_contributor(
-                temp_dir, request.gitUrl, author_name, author_email
+                temp_dir, request.gitUrl, author_name, author_email, request.techstacks
             )
             analysis_elapsed = time.time() - analysis_start
             logger.info(f"{log_prefix} AI 분석 완료 ({analysis_elapsed:.2f}초)")
@@ -285,10 +291,15 @@ class AnalyzerService:
                 self._create_embedding_and_callback(request, analysis_result, log_prefix)
             )
 
+            # techstacks 추출 (AI 응답에서)
+            techstacks = analysis_result.pop("techstacks", []) if isinstance(analysis_result, dict) else []
+            logger.info(f"{log_prefix} AI 응답 techstacks: {techstacks}")
+
             return {
                 "status": "SUCCESS",
                 "content": analysis_result,
-                "errorMessage": None
+                "errorMessage": None,
+                "techstacks": techstacks
             }
 
         except Exception as e:
@@ -297,7 +308,8 @@ class AnalyzerService:
             return {
                 "status": "FAILED",
                 "content": None,
-                "errorMessage": str(e)
+                "errorMessage": str(e),
+                "techstacks": []
             }
 
         finally:

--- a/app/services/callback_service.py
+++ b/app/services/callback_service.py
@@ -15,14 +15,16 @@ class CallbackService:
         main_report_id: int,
         status: str,
         content: Optional[Any] = None,
-        error_message: Optional[str] = None
+        error_message: Optional[str] = None,
+        techstacks: Optional[List[str]] = None
     ):
         payload = CallbackReq(
             detailReportId=detail_report_id,
             mainReportId=main_report_id,
             status=status,
             content=content,
-            errorMessage=error_message
+            errorMessage=error_message,
+            techstacks=techstacks
         )
 
         try:
@@ -41,13 +43,21 @@ class CallbackService:
         except httpx.RequestError as e:
             raise CallbackException(f"콜백 전송 중 오류: {str(e)}")
 
-    async def send_success(self, callback_url: str, detail_report_id: int, main_report_id: int, content: Any):
+    async def send_success(
+        self,
+        callback_url: str,
+        detail_report_id: int,
+        main_report_id: int,
+        content: Any,
+        techstacks: Optional[List[str]] = None
+    ):
         await self.send_callback(
             callback_url=callback_url,
             detail_report_id=detail_report_id,
             main_report_id=main_report_id,
             status="SUCCESS",
-            content=content
+            content=content,
+            techstacks=techstacks
         )
 
     async def send_failure(self, callback_url: str, detail_report_id: int, main_report_id: int, error_message: str):


### PR DESCRIPTION
# 요약

리포트 생성 시 기여자가 직접 사용한 기술 스택을 enum 기반으로 분류하여 반환하는 기능 추가

 - 요청/응답 DTO 및 컨트롤러에 techstacks 필드 추가
 - AI 프롬프트에 techstack enum 목록 추가 및 개인 기여자 기준으로 분류하도록 규칙 정의
 - 분석 서비스에서 techstacks를 파이프라인에 전달하고 AI 응답에서 추출하도록 구현
 - 콜백 서비스에 techstacks 전달 기능 추가
 - AI 응답 techstacks 디버깅 로그 추가

# 연관 이슈 및 Close 할 이슈 작성

close #25

# Pull Request 체크리스트

## TODO

- [x] 최종 결과물을 확인했는가?
- [x] 의미 있는 커밋 메시지를 작성했는가?