### PR TITLE
[BUILD] CD 블루/그린 배포 방식으로 전환

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -26,12 +26,12 @@ jobs:
         port: ${{ secrets.EC2_SSH_PORT }}
         timeout: 300s
         script: |
-          cd ~/Devine_Deploy/service
-
           # 최신 배포 스크립트 동기화
-          git pull origin main
+          cd ~/Devine_Deploy || exit 1
+          git pull origin main || { echo "ERROR: git pull failed"; exit 1; }
 
           # S3에서 환경변수 다운로드
+          cd ~/Devine_Deploy/service || exit 1
           aws s3 cp s3://${{ secrets.S3_BUCKET_NAME }}/config/.env .env
           if [ ! -f .env ]; then
             echo "ERROR: .env download failed"
@@ -40,4 +40,4 @@ jobs:
 
           # Blue/Green 배포 실행
           chmod +x deploy.sh
-          ./deploy.sh ai ${{ github.sha }}
+          ./deploy.sh ai sha-${{ github.event.workflow_run.head_sha }}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -48,7 +48,7 @@ jobs:
         images: ${{ env.DOCKER_IMAGE }}
         tags: |
           type=raw,value=latest
-          type=sha,prefix=
+          type=sha,prefix=sha-,format=long
 
     - uses: docker/build-push-action@v5
       with:


### PR DESCRIPTION
# 요약
<!--해당 PR에 대한 설명 혹은 이미지등을 넣어주세요. -->

- 기존 배포 로직을 deploy.sh 스크립트로 외부화하고 Blue/Green 배포를 적용
- 동시 배포를 방지하고 순차적으로 실행되도록 Concurrency 그룹을 설정
- 빌드된 Docker 이미지의 SHA를 배포 스크립트에 전달하여 특정 버전 배포 보장
- 빌드 Job에서 생성된 이미지 태그를 output으로 지정하여 후속 Job에서 활용 가능하도록 함

* https://github.com/DeVine-2025/DeVine_BackEnd/pull/235

# 연관 이슈 및 Close 할 이슈 작성
(fix #일이삼)
<!--이슈 번호를 적어주세요(예시: fix #123). -->

-- PR 시 다음과 같이 작성
#40

close #40

# Pull Request 체크리스트

## TODO

- [x] 최종 결과물을 확인했는가?
- [x] 의미 있는 커밋 메시지를 작성했는가?
   