### PR TITLE
[Refactor] google-genai SDK 마이그레이션 및 파일 탐색/프롬프트 구조 개선

### DIFF
--- a/app/prompts/combined_report_prompt.py
+++ b/app/prompts/combined_report_prompt.py
@@ -1,14 +1,13 @@
-COMBINED_REPORT_PROMPT = """
-You are an expert at analyzing software project contributions and writing comprehensive reports.
-IMPORTANT: You must write all the values within the JSON response in KOREAN (한국어).
+from typing import List, Optional
 
+COMBINED_REPORT_PROMPT = """\
 The following is the contribution analysis for "{author_name}" in the repository "{repo_url}".
 
 === Project Information ===
 Repository: {repo_url}
 Total Commits: {total_commits}
 Commits by {author_name}: {user_commits}
-Contribution Ratio: {contribution_ratio}%
+Contribution Ratio: {contribution_ratio:.1f}%
 
 === Tech Stack ===
 {tech_stack}
@@ -145,28 +144,23 @@ Important Requirements:
   - Only list features that EXIST in the codebase but were implemented by other people
 - Group implemented features by category (e.g., Security, File Processing, API Integration, etc.).
 - Write code locations based on the actual project structure provided.
-- **Array Length Guidelines**:
-  - main.overview.capabilities: Provide exactly 5 items
-  - main.projectInfo.techStack: Provide 5-10 items
-  - main.keyImplementations: Provide exactly 4 items
-  - main.keyImplementations[].capabilities: Provide exactly 4 items
-  - main.aiEvaluation: Provide exactly 3 items
-  - main.aiEvaluation[].details: Provide exactly 3 items
-  - main.recommendations: Provide exactly 3 items
-  - detail.implementedFeatures: Provide up to 5 categories
-  - detail.implementedFeatures[].features: Provide 2-4 items per category
-  - detail.implementedFeatures[].features[].implementation: Provide 2-3 items
-  - detail.implementedFeatures[].features[].details: Provide 2-3 items
-  - detail.projectSummary.implemented: Provide 3-5 items
-  - detail.projectSummary.notImplemented: Provide 1-3 items
-  - detail.codeInsights: Provide exactly 4 items
-  - detail.codeInsights[].points: Provide 2-3 items
-  - detail.improvements: Provide exactly 3 items
-  - detail.improvements[].currentState: Provide 1-2 items
-  - detail.improvements[].suggestions: Provide 2-3 items
-  - detail.nextSteps: Provide exactly 3 items
-  - detail.nextSteps[].description: Provide 2-3 items
-  - detail.nextSteps[].recommendKeyword: Provide 2-3 items
+- **codeLocation is REQUIRED** (must have at least 1 item, never empty):
+  - detail.implementedFeatures[].features[].codeLocation: always provide actual file paths from the project structure
+  - detail.codeInsights[].codeLocation: always provide actual file paths relevant to the insight
+- Array length requirements:
+  - main.overview.capabilities: exactly 5 items
+  - main.projectInfo.techStack: 5-10 items
+  - main.keyImplementations: exactly 4 items, each with exactly 4 capabilities
+  - main.aiEvaluation: exactly 3 items, each with exactly 3 details
+  - main.recommendations: exactly 3 items
+  - detail.implementedFeatures: up to 5 categories, each with 2-4 features
+  - detail.implementedFeatures[].features[].implementation: 2-3 items
+  - detail.implementedFeatures[].features[].details: 2-3 items
+  - detail.projectSummary.implemented: 3-5 items
+  - detail.projectSummary.notImplemented: 1-3 items
+  - detail.codeInsights: exactly 4 items, each with 2-3 points
+  - detail.improvements: exactly 3 items, each with 1-2 currentState and 2-3 suggestions
+  - detail.nextSteps: exactly 3 items, each with 2-3 description and 2-3 recommendKeyword
 - **techStack Rules (IMPORTANT)**:
   - Include as many applicable categories as possible based on the project.
   - ONLY include categories where actual technologies are used in the project. Do NOT include empty or irrelevant categories.
@@ -182,7 +176,6 @@ Important Requirements:
 - **Tech Stack Version Rules**:
   - Extract version information (e.g., Java 17, Spring Boot 3.2, Node 18, Python 3.11) from the ENTIRE project's build/config files (pom.xml, build.gradle, package.json, requirements.txt, pyproject.toml, .nvmrc, etc.), NOT just {author_name}'s commits.
   - Always include the specific version number when available (e.g., "Java 17" not just "Java").
-- Respond strictly in JSON format only.
 - **techstacks Rules (CRITICAL)**:
   - The "techstacks" field must be a string array containing ONLY values from the "Available Techstack Enum Values" section above.
   - Select ONLY the techstacks that "{author_name}" actually used based on their commits, code changes, and modified files — NOT the entire project's tech stack.
@@ -191,9 +184,6 @@ Important Requirements:
   - Return exact enum names as strings (e.g., "JAVA", "SPRINGBOOT", "REACT", "TYPESCRIPT").
   - Example: If "{author_name}" worked on Java backend with Spring Boot and MySQL queries, return ["JAVA", "SPRINGBOOT", "MYSQL"].
 """
-
-
-from typing import List, Optional
 
 
 def get_combined_report_prompt(

--- a/app/services/gemini_service.py
+++ b/app/services/gemini_service.py
@@ -1,8 +1,8 @@
 import re
 import json
-import asyncio
 import logging
-import google.generativeai as genai
+from google import genai
+from google.genai import types, errors
 from json_repair import repair_json
 from tenacity import (
     retry,
@@ -16,14 +16,190 @@ from app.utils.webhook import discord_send_message
 
 logger = logging.getLogger(__name__)
 
-genai.configure(api_key=settings.gemini_api_key)
+client = genai.Client(api_key=settings.gemini_api_key)
 
 
-FALLBACK_MODELS = ["gemini-2.5-flash", "gemini-2.5-pro", "gemini-2.0-flash"]
+_REPORT_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "techstacks": {"type": "array", "items": {"type": "string"}},
+        "main": {
+            "type": "object",
+            "properties": {
+                "overview": {
+                    "type": "object",
+                    "properties": {
+                        "summary": {"type": "string"},
+                        "mainTech": {"type": "string"},
+                        "capabilities": {"type": "array", "items": {"type": "string"}},
+                        "scale": {"type": "string"},
+                    },
+                    "required": ["summary", "mainTech", "capabilities", "scale"],
+                },
+                "projectInfo": {
+                    "type": "object",
+                    "properties": {
+                        "projectName": {"type": "string"},
+                        "techStack": {"type": "array", "items": {"type": "string"}},
+                        "scale": {"type": "string"},
+                    },
+                    "required": ["projectName", "techStack", "scale"],
+                },
+                "keyImplementations": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "title": {"type": "string"},
+                            "description": {"type": "string"},
+                            "capabilities": {"type": "array", "items": {"type": "string"}},
+                        },
+                        "required": ["title", "description", "capabilities"],
+                    },
+                },
+                "aiEvaluation": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "title": {"type": "string"},
+                            "details": {"type": "array", "items": {"type": "string"}},
+                        },
+                        "required": ["title", "details"],
+                    },
+                },
+                "recommendations": {"type": "array", "items": {"type": "string"}},
+            },
+            "required": ["overview", "projectInfo", "keyImplementations", "aiEvaluation", "recommendations"],
+        },
+        "detail": {
+            "type": "object",
+            "properties": {
+                "reportTitle": {"type": "string"},
+                "reportSubtitle": {"type": "string"},
+                "projectOverview": {
+                    "type": "object",
+                    "properties": {
+                        "purpose": {"type": "string"},
+                        "techStack": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "title": {"type": "string"},
+                                    "content": {"type": "string"},
+                                },
+                                "required": ["title", "content"],
+                            },
+                        },
+                        "projectScale": {
+                            "type": "object",
+                            "properties": {
+                                "mainCodeFiles": {"type": "number"},
+                                "totalCodeLines": {"type": "number"},
+                                "developmentPeriod": {"type": "string"},
+                                "architecturePattern": {"type": "string"},
+                            },
+                            "required": ["mainCodeFiles", "totalCodeLines", "developmentPeriod", "architecturePattern"],
+                        },
+                    },
+                    "required": ["purpose", "techStack", "projectScale"],
+                },
+                "implementedFeatures": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "category": {"type": "string"},
+                            "categoryNumber": {"type": "number"},
+                            "features": {
+                                "type": "array",
+                                "items": {
+                                    "type": "object",
+                                    "properties": {
+                                        "name": {"type": "string"},
+                                        "implementation": {"type": "array", "items": {"type": "string"}},
+                                        "codeLocation": {"type": "array", "items": {"type": "string"}},
+                                        "details": {"type": "array", "items": {"type": "string"}},
+                                    },
+                                    "required": ["name", "implementation", "codeLocation", "details"],
+                                },
+                            },
+                        },
+                        "required": ["category", "categoryNumber", "features"],
+                    },
+                },
+                "projectSummary": {
+                    "type": "object",
+                    "properties": {
+                        "implemented": {"type": "array", "items": {"type": "string"}},
+                        "notImplemented": {"type": "array", "items": {"type": "string"}},
+                    },
+                    "required": ["implemented", "notImplemented"],
+                },
+                "codeInsights": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "number": {"type": "number"},
+                            "title": {"type": "string"},
+                            "points": {"type": "array", "items": {"type": "string"}},
+                            "codeLocation": {"type": "array", "items": {"type": "string"}},
+                        },
+                        "required": ["number", "title", "points", "codeLocation"],
+                    },
+                },
+                "improvements": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "number": {"type": "number"},
+                            "title": {"type": "string"},
+                            "currentState": {"type": "array", "items": {"type": "string"}},
+                            "suggestions": {"type": "array", "items": {"type": "string"}},
+                            "keywords": {"type": "string"},
+                        },
+                        "required": ["number", "title", "currentState", "suggestions", "keywords"],
+                    },
+                },
+                "nextSteps": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "number": {"type": "number"},
+                            "title": {"type": "string"},
+                            "description": {"type": "array", "items": {"type": "string"}},
+                            "recommendKeyword": {"type": "array", "items": {"type": "string"}},
+                        },
+                        "required": ["number", "title", "description", "recommendKeyword"],
+                    },
+                },
+            },
+            "required": ["reportTitle", "reportSubtitle", "projectOverview", "implementedFeatures", "projectSummary", "codeInsights", "improvements", "nextSteps"],
+        },
+    },
+    "required": ["techstacks", "main", "detail"],
+}
 
 
 class GeminiService:
-    def _parse_json_response(self, text: str) -> dict:
+    FALLBACK_MODELS = ["gemini-2.5-flash", "gemini-2.5-pro", "gemini-2.0-flash"]
+    SYSTEM_INSTRUCTION = (
+        "You are an expert at analyzing software project contributions and writing comprehensive reports. "
+        "Write all values in the JSON response in Korean (한국어)."
+    )
+    REPORT_SCHEMA = _REPORT_SCHEMA
+
+    # 각 모델별 입력 토큰 한도
+    FLASH_TOKEN_LIMIT = 1_000_000  # gemini-2.5-flash: 1M
+    PRO_TOKEN_LIMIT = 2_000_000  # gemini-2.5-pro:   2M
+    # gemini-2.0-flash: 4M (초과 시 모두 실패로 처리)
+
+    @staticmethod
+    def _parse_json_response(text: str) -> dict:
         """JSON 응답 파싱 - 실패 시 복구 시도"""
         # 1차: 직접 파싱 시도
         try:
@@ -56,30 +232,34 @@ class GeminiService:
     @retry(
         stop=stop_after_attempt(3),
         wait=wait_exponential(multiplier=1, min=2, max=10),
-        retry=retry_if_exception_type(GeminiException),
+        retry=retry_if_exception_type(errors.ServerError),
         reraise=True,
     )
-    def _generate_content_sync(self, prompt: str, model_name: str) -> tuple[dict, object]:
-        model = genai.GenerativeModel(model_name)
-        response = model.generate_content(
-            prompt,
-            generation_config=genai.GenerationConfig(
-                response_mime_type="application/json"
+    async def _generate_content(
+        self, prompt: str, model_name: str
+    ) -> tuple[dict, object]:
+        response = await client.aio.models.generate_content(
+            model=model_name,
+            contents=prompt,
+            config=types.GenerateContentConfig(
+                system_instruction=self.SYSTEM_INSTRUCTION,
+                response_mime_type="application/json",
+                response_schema=self.REPORT_SCHEMA,
             ),
         )
 
         text = response.text
+        if not text:
+            raise GeminiException("Gemini 응답이 비어있습니다 (Safety filter 또는 빈 응답)")
         return self._parse_json_response(text), response.usage_metadata
 
-    # 각 모델별 입력 토큰 한도
-    FLASH_TOKEN_LIMIT = 1_000_000  # gemini-2.5-flash: 1M
-    PRO_TOKEN_LIMIT = 2_000_000  # gemini-2.5-pro:   2M
-    # gemini-2.0-flash: 4M (초과 시 모두 실패로 처리)
-
-    def _count_tokens_sync(self, prompt: str) -> int:
+    async def _count_tokens(self, prompt: str) -> int:
         """프롬프트 토큰 수 측정"""
-        model = genai.GenerativeModel(FALLBACK_MODELS[0])
-        return model.count_tokens(prompt).total_tokens
+        response = await client.aio.models.count_tokens(
+            model=self.FALLBACK_MODELS[0],
+            contents=prompt,
+        )
+        return response.total_tokens
 
     def _select_start_model(self, token_count: int) -> int:
         """토큰 수에 따라 시작할 FALLBACK_MODELS 인덱스 반환"""
@@ -87,16 +267,10 @@ class GeminiService:
             logger.info(
                 f"토큰 수 {token_count:,} > {self.PRO_TOKEN_LIMIT:,}, gemini-2.0-flash로 시작"
             )
-            discord_send_message(
-                f"프롬프트 토큰 수 {token_count:,}개 - pro 한도 초과, {FALLBACK_MODELS[2]}로 시작"
-            )
             return 2  # gemini-2.0-flash
         if token_count > self.FLASH_TOKEN_LIMIT:
             logger.info(
                 f"토큰 수 {token_count:,} > {self.FLASH_TOKEN_LIMIT:,}, gemini-2.5-pro로 시작"
-            )
-            discord_send_message(
-                f"프롬프트 토큰 수 {token_count:,}개 - flash 한도 초과, {FALLBACK_MODELS[1]}로 시작"
             )
             return 1  # gemini-2.5-pro
         return 0  # gemini-2.5-flash
@@ -111,7 +285,6 @@ class GeminiService:
             "context_length",
             "input_token",
             "payload size",
-            "resource_exhausted",
             "context_window",
             "input too long",
             "maximum context",
@@ -119,7 +292,7 @@ class GeminiService:
         if any(k in error_str for k in token_keywords):
             return True
         # 400이 size/length 관련일 때만 토큰 에러로 간주
-        if "400" in error_str and any(
+        if "400" in error_str and "invalid_argument" not in error_str and any(
             k in error_str for k in ("size", "length", "limit")
         ):
             return True
@@ -128,19 +301,21 @@ class GeminiService:
     async def generate_content(self, prompt: str) -> dict:
         # 토큰 수 측정 후 시작 모델 결정
         try:
-            token_count = await asyncio.to_thread(self._count_tokens_sync, prompt)
+            token_count = await self._count_tokens(prompt)
             logger.info(f"프롬프트 토큰 수: {token_count:,}")
         except Exception as e:
             logger.warning(f"토큰 카운트 실패, flash로 시작: {e}")
             token_count = 0
 
         start_idx = self._select_start_model(token_count)
+        if start_idx > 0:
+            discord_send_message(
+                f"프롬프트 토큰 수 {token_count:,}개 - {self.FALLBACK_MODELS[start_idx]}로 시작"
+            )
 
-        for model_name in FALLBACK_MODELS[start_idx:]:
+        for current_idx, model_name in enumerate(self.FALLBACK_MODELS[start_idx:], start=start_idx):
             try:
-                result, usage = await asyncio.to_thread(
-                    self._generate_content_sync, prompt, model_name
-                )
+                result, usage = await self._generate_content(prompt, model_name)
                 if usage:
                     input_tokens = usage.prompt_token_count
                     output_tokens = usage.candidates_token_count
@@ -148,27 +323,29 @@ class GeminiService:
                     logger.info(
                         f"[{model_name}] 토큰 사용량 - 입력: {input_tokens:,}, 출력: {output_tokens:,}, 합계: {total_tokens:,}"
                     )
-                    discord_send_message(
-                        f"[{model_name}] 토큰 사용량 — 입력: {input_tokens:,} / 출력: {output_tokens:,} / 합계: {total_tokens:,}"
-                    )
                 return result
             except Exception as e:
                 error_str = str(e).lower()
-                current_idx = FALLBACK_MODELS.index(model_name)
-                is_last_model = current_idx == len(FALLBACK_MODELS) - 1
+                is_last_model = current_idx == len(self.FALLBACK_MODELS) - 1
 
                 if self._is_token_error(error_str):
                     if not is_last_model:
-                        next_model = FALLBACK_MODELS[current_idx + 1]
+                        next_model = self.FALLBACK_MODELS[current_idx + 1]
+                        logger.warning(
+                            f"{model_name} 토큰 에러, {next_model}로 전환: {e}"
+                        )
                         discord_send_message(
                             f"{model_name} 토큰 에러 발생, {next_model}로 전환 시도: {str(e)}"
                         )
-                        logger.warning(f"{model_name} 토큰 에러, {next_model}로 전환: {e}")
                         continue
-                    discord_send_message(f"모든 모델 토큰 한도 초과, 분석 불가: {str(e)}")
-                    raise GeminiException(f"모든 모델 토큰 한도 초과: {str(e)}")
+                    logger.error(f"모든 모델 토큰 한도 초과, 분석 불가: {e}")
+                    discord_send_message(
+                        f"모든 모델 토큰 한도 초과, 분석 불가: {str(e)}"
+                    )
+                    raise GeminiException(f"모든 모델 토큰 한도 초과: {str(e)}") from e
+                logger.error(f"{model_name} API 호출 실패: {e}")
                 discord_send_message(f"{model_name} API 호출 실패: {str(e)}")
-                raise GeminiException(f"Gemini API 호출 실패: {str(e)}")
+                raise GeminiException(f"Gemini API 호출 실패: {str(e)}") from e
 
     async def analyze_code(self, prompt: str) -> dict:
         return await self.generate_content(prompt)

--- a/app/utils/file_reader.py
+++ b/app/utils/file_reader.py
@@ -1,21 +1,23 @@
 import os
+import subprocess
 from typing import List, Dict
 
-CODE_EXTENSIONS = [
-    ".py", ".js", ".jsx", ".ts", ".tsx", ".java", ".kt", ".swift",
-    ".go", ".rs", ".rb", ".php", ".cs", ".cpp", ".c", ".h",
-    ".vue", ".svelte", ".html", ".css", ".scss", ".sass", ".less"
-]
+from binaryornot.check import is_binary
 
 SKIP_DIRS = [
     "node_modules", "vendor", "dist", "build", ".git", "__pycache__",
     ".next", "coverage", ".venv", "venv", "env", ".idea", ".vscode"
 ]
 
-SKIP_FILES = [
+# 자동생성 락파일 (내용이 의미 없는 파일)
+SKIP_FILES = {
+    # 패키지 락파일
     "package-lock.json", "yarn.lock", "pnpm-lock.yaml",
-    ".DS_Store", "Thumbs.db"
-]
+    "Pipfile.lock", "poetry.lock", "composer.lock",
+    "Gemfile.lock", "Cargo.lock", "mix.lock",
+    # OS 메타데이터
+    ".DS_Store", "Thumbs.db", "desktop.ini",
+}
 
 
 def get_all_files(dir_path: str) -> List[str]:
@@ -34,14 +36,49 @@ def get_all_files(dir_path: str) -> List[str]:
     return files
 
 
+def get_git_tracked_files(dir_path: str) -> List[str]:
+    """git ls-files로 추적 중인 파일만 반환. git 환경이 아니면 get_all_files로 fallback."""
+    try:
+        result = subprocess.run(
+            ["git", "ls-files"],
+            cwd=dir_path,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="ignore",
+        )
+        if result.returncode == 0 and result.stdout.strip():
+            return [f for f in result.stdout.strip().split("\n") if f]
+    except Exception:
+        pass
+    return get_all_files(dir_path)
+
+
 def get_code_files(dir_path: str) -> List[str]:
-    all_files = get_all_files(dir_path)
+    """git 추적 파일 기준으로 바이너리/자동생성 파일을 제외한 작업 파일 목록 반환."""
+    all_files = get_git_tracked_files(dir_path)
 
     code_files = []
     for file in all_files:
-        ext = os.path.splitext(file)[1].lower()
-        if ext in CODE_EXTENSIONS:
-            code_files.append(file)
+        filename = os.path.basename(file)
+
+        # 락파일/OS 메타 스킵
+        if filename in SKIP_FILES:
+            continue
+
+        # 미니파이된 파일 스킵 (예: bundle.min.js, app.min.css)
+        if ".min." in filename:
+            continue
+
+        # 실제 파일 내용 기반 바이너리 판별
+        abs_path = os.path.join(dir_path, file)
+        try:
+            if is_binary(abs_path):
+                continue
+        except Exception:
+            continue
+
+        code_files.append(file)
 
     return code_files
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ gitpython==3.1.46
 requests==2.32.5
 pydantic==2.12.5
 pydantic-settings>=2.0.0
-google-generativeai==0.8.6
+google-genai>=1.0.0
 python-dotenv>=1.0.0
 tenacity>=8.0.0
 
@@ -16,3 +16,4 @@ pytest>=8.0.0
 pytest-asyncio>=0.23.0
 
 json-repair>=0.30.0
+binaryornot>=0.4.4


### PR DESCRIPTION
# 요약

세 커밋 모두 IssueNum #54 작업의 일부로, google-genai SDK 마이그레이션과 그에 따른 후속 정리, 그리고 비코드 파일 규모 측정 버그 수정을 포함합니다.

- **[Fix] 비코드 파일 규모 측정 누락 문제 해결** (`app/utils/file_reader.py`)
  - 확장자 화이트리스트(`CODE_EXTENSIONS`)를 제거하고 `binaryornot` 기반 바이너리 판별로 전환
  - `git ls-files` 기준으로 추적 파일만 수집 (fallback 유지)
  - 패키지 락파일/OS 메타데이터/미니파이 파일 스킵 규칙 보강

- **[Refactor] google-genai SDK 마이그레이션 및 response_schema 도입** (`app/services/gemini_service.py`, `requirements.txt`)
  - `google-generativeai 0.8.6` → `google-genai 1.0+` 패키지 교체
  - `genai.Client` 기반 async API(`client.aio`)로 전환, `asyncio.to_thread` 제거
  - `response_schema` 적용으로 반환 JSON 구조 고정 및 누락 필드 방지
  - `system_instruction` 분리, 빈 응답(Safety filter) 명시적 예외 처리
  - `ServerError` 기준으로 retry 조건 정리, 토큰 에러 판별 로직 보정

- **[Refactor] response_schema 도입에 따른 프롬프트 정리** (`app/prompts/combined_report_prompt.py`)
  - schema로 강제되는 array 길이 규칙 중복 서술 축약 및 정리
  - `codeLocation` 필수 명시 (schema required와 일치)
  - `contribution_ratio` 포맷 지정(`.1f`) 및 import 위치 정리

# 연관 이슈 및 Close 할 이슈 작성

#54

close #54

# Pull Request 체크리스트

## TODO

- [x] 최종 결과물을 확인했는가?
- [x] 의미 있는 커밋 메시지를 작성했는가?
